### PR TITLE
Quality of life patches

### DIFF
--- a/generate_wine.sh
+++ b/generate_wine.sh
@@ -18,24 +18,18 @@
 
 for f in $( ls *.exe ); do 
 CURRENT=$(pwd)
-f=$(echo $f | sed 's/.exe$//')
-echo $f
-echo "#!/bin/bash" > $f
-echo -n "WINEDEBUG=-all WINEPREFIX=" >> $f
-echo -n $CURRENT >> $f
-echo -n "/.wineconf wine " >> $f
-echo -n $CURRENT >> $f
-echo -n "/" >> $f
-echo -n $f >> $f
-echo -n ".exe \"$" >> $f
-echo "@\"" >> $f
-chmod +x $f
+f="$(echo $f | sed 's/.exe$//')"
+echo "$f"
+echo "#!/bin/bash" > "$f"
+echo 'BIN_DIR="$(dirname "$0")"' >> "$f"
+echo 'WINEDEBUG=-all WINEPREFIX="$BIN_DIR/.wineconf" wine "$BIN_DIR/$(basename "$0").exe" "$@"' >> "$f"
+chmod +x "$f"
 done
 
 DIVLINE=$(grep -n -m 1 common.mk ../makefile.gen | sed  's/\([0-9]*\).*/\1/')
 WINEGEN="../makefile_wine.gen"
 head -n $DIVLINE ../makefile.gen > $WINEGEN
-tail +42 $0 >> $WINEGEN
+tail +36 "$0" >> $WINEGEN
 tail +$DIVLINE ../makefile.gen | tail +2 >> $WINEGEN
 : <<'# end of section'
 

--- a/generate_wine.sh
+++ b/generate_wine.sh
@@ -29,25 +29,24 @@ done
 DIVLINE=$(grep -n -m 1 common.mk ../makefile.gen | sed  's/\([0-9]*\).*/\1/')
 WINEGEN="../makefile_wine.gen"
 head -n $DIVLINE ../makefile.gen > $WINEGEN
-tail +36 "$0" >> $WINEGEN
-tail +$DIVLINE ../makefile.gen | tail +2 >> $WINEGEN
-: <<'# end of section'
-
+cat >> $WINEGEN <<EOF
 # section added by generate_wine.sh
 RM= rm
 CP= cp
 MKDIR= mkdir
-CC= $(GDK)/bin/gcc
-LD= $(GDK)/bin/ld
-NM= $(GDK)/bin/nm
+CC= \$(GDK)/bin/gcc
+LD= \$(GDK)/bin/ld
+NM= \$(GDK)/bin/nm
 JAVA= java
 ECHO= echo
-OBJCPY= $(GDK)/bin/objcopy
-ASMZ80= $(GDK)/bin/sjasm
-MACCER= $(GDK)/bin/mac68k
-SIZEBND= $(JAVA) -jar $(GDK)/bin/sizebnd.jar
-BINTOS= $(GDK)/bin/bintos
-RESCOMP= $(JAVA) -jar $(GDK)/bin/rescomp.jar
-release: LIBGCC= $(LIB)/libgcc.a
-debug: LIBGCC= $(LIB)/libgcc.a
+OBJCPY= \$(GDK)/bin/objcopy
+ASMZ80= \$(GDK)/bin/sjasm
+MACCER= \$(GDK)/bin/mac68k
+SIZEBND= \$(JAVA) -jar \$(GDK)/bin/sizebnd.jar
+BINTOS= \$(GDK)/bin/bintos
+RESCOMP= \$(JAVA) -jar \$(GDK)/bin/rescomp.jar
+release: LIBGCC= \$(LIB)/libgcc.a
+debug: LIBGCC= \$(LIB)/libgcc.a
 # end of section
+EOF
+tail +$DIVLINE ../makefile.gen | tail +2 >> $WINEGEN


### PR DESCRIPTION
Hey! Thanks for the wrapper!

As a new user I hit minor quality of life issues. With these patchs:
 - We can move the SGDK folder without needing to re-generate the wrappers
 - When modifying `generate_wine.sh`, no more need to worry about the hardcoded line number

As a bonus, I added more quotes in case there is a space in a path.

By the way. I am running Archlinux and it worked without issue.